### PR TITLE
Fix JSON query in openapi.yml

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -54,7 +54,7 @@ jobs:
             id: "simple_pay"
             run: |
                 VERSION="$(
-                    jq -r ."info.version" ./openapi.json
+                    jq -r '."info"."version"' ./openapi.json
                 )"
                 echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
         -


### PR DESCRIPTION
single quotes - for shell
double quotes - for JSON names