### PR TITLE
Fix type in openapi.json

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -348,7 +348,7 @@
             },
             "TransactionId": {
                 "type": "number",
-                "example": "99844942"
+                "example": 99844942
             },
             "Method": {
                 "type": "string",


### PR DESCRIPTION
**oas-validation.com**

Context: Schema: AuthorizedTransaction, Property: transactionId
Example:

99844942

Error: '99844942' is not of type 'number' Failed validating 'type' in schema: {'type': 'number', 'example': '99844942'} On instance: '99844942'
